### PR TITLE
Light client: replace concrete client type with interface for IBC module keeper

### DIFF
--- a/modules/core/02-client/abci.go
+++ b/modules/core/02-client/abci.go
@@ -3,13 +3,13 @@ package client
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
 )
 
 // BeginBlocker updates an existing localhost client with the latest block height.
-func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+func BeginBlocker(ctx sdk.Context, k clientexported.ClientKeeper) {
 	plan, found := k.GetUpgradePlan(ctx)
 	if found {
 		// Once we are at the last block this chain will commit, set the upgraded consensus state

--- a/modules/core/02-client/exported/expected_keepers.go
+++ b/modules/core/02-client/exported/expected_keepers.go
@@ -1,0 +1,73 @@
+package exported
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+)
+
+// ClientKeeper defines the expected interface of the light client used for IBC
+type ClientKeeper interface {
+	CreateClient(ctx sdk.Context, clientState exported.ClientState, consensusState exported.ConsensusState) (string, error)
+	UpdateClient(ctx sdk.Context, clientID string, header exported.Header) error
+	UpgradeClient(ctx sdk.Context, clientID string, upgradedClient exported.ClientState, upgradedConsState exported.ConsensusState, proofUpgradeClient, proofUpgradeConsState []byte) error
+	CheckMisbehaviourAndUpdateState(ctx sdk.Context, misbehaviour exported.Misbehaviour) error
+	GenerateClientIdentifier(ctx sdk.Context, clientType string) string
+	SetClientState(ctx sdk.Context, clientID string, clientState exported.ClientState)
+	GetClientState(ctx sdk.Context, clientID string) (exported.ClientState, bool)
+	GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool)
+	SetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height, consensusState exported.ConsensusState)
+	GetNextClientSequence(ctx sdk.Context) uint64
+	SetNextClientSequence(ctx sdk.Context, sequence uint64)
+	IterateConsensusStates(ctx sdk.Context, cb func(clientID string, cs clienttypes.ConsensusStateWithHeight) bool)
+	GetAllGenesisClients(ctx sdk.Context) clienttypes.IdentifiedClientStates
+	GetAllClientMetadata(ctx sdk.Context, genClients []clienttypes.IdentifiedClientState) ([]clienttypes.IdentifiedGenesisMetadata, error)
+	SetAllClientMetadata(ctx sdk.Context, genMetadata []clienttypes.IdentifiedGenesisMetadata)
+	GetAllConsensusStates(ctx sdk.Context) clienttypes.ClientsConsensusStates
+	HasClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) bool
+	GetLatestClientConsensusState(ctx sdk.Context, clientID string) (exported.ConsensusState, bool)
+	GetSelfConsensusState(ctx sdk.Context, height exported.Height) (exported.ConsensusState, error)
+	ValidateSelfClient(ctx sdk.Context, clientState exported.ClientState) error
+	GetUpgradePlan(ctx sdk.Context) (plan upgradetypes.Plan, havePlan bool)
+	GetUpgradedClient(ctx sdk.Context, planHeight int64) ([]byte, bool)
+	GetUpgradedConsensusState(ctx sdk.Context, planHeight int64) ([]byte, bool)
+	SetUpgradedConsensusState(ctx sdk.Context, planHeight int64, bz []byte) error
+	IterateClients(ctx sdk.Context, cb func(clientID string, cs exported.ClientState) bool)
+	GetAllClients(ctx sdk.Context) (states []exported.ClientState)
+	ClientStore(ctx sdk.Context, clientID string) sdk.KVStore
+
+	// encoding-related functions
+	UnmarshalClientState(bz []byte) (exported.ClientState, error)
+	MustUnmarshalClientState(bz []byte) exported.ClientState
+	UnmarshalConsensusState(bz []byte) (exported.ConsensusState, error)
+	MustUnmarshalConsensusState(bz []byte) exported.ConsensusState
+	MustMarshalClientState(clientState exported.ClientState) []byte
+	MustMarshalConsensusState(consensusState exported.ConsensusState) []byte
+	GetStoreKey() storetypes.StoreKey
+	GetCdc() codec.BinaryCodec
+
+	// params-related functions
+	GetAllowedClients(ctx sdk.Context) []string
+	GetParams(ctx sdk.Context) clienttypes.Params
+	SetParams(ctx sdk.Context, params clienttypes.Params)
+
+	// proposal-related functions
+	ClientUpdateProposal(ctx sdk.Context, p *clienttypes.ClientUpdateProposal) error
+	HandleUpgradeProposal(ctx sdk.Context, p *clienttypes.UpgradeProposal) error
+
+	// GRPC query functions
+	ClientState(context.Context, *clienttypes.QueryClientStateRequest) (*clienttypes.QueryClientStateResponse, error)
+	ClientStates(context.Context, *clienttypes.QueryClientStatesRequest) (*clienttypes.QueryClientStatesResponse, error)
+	ConsensusState(context.Context, *clienttypes.QueryConsensusStateRequest) (*clienttypes.QueryConsensusStateResponse, error)
+	ConsensusStates(context.Context, *clienttypes.QueryConsensusStatesRequest) (*clienttypes.QueryConsensusStatesResponse, error)
+	ConsensusStateHeights(context.Context, *clienttypes.QueryConsensusStateHeightsRequest) (*clienttypes.QueryConsensusStateHeightsResponse, error)
+	ClientStatus(context.Context, *clienttypes.QueryClientStatusRequest) (*clienttypes.QueryClientStatusResponse, error)
+	ClientParams(context.Context, *clienttypes.QueryClientParamsRequest) (*clienttypes.QueryClientParamsResponse, error)
+	UpgradedClientState(context.Context, *clienttypes.QueryUpgradedClientStateRequest) (*clienttypes.QueryUpgradedClientStateResponse, error)
+	UpgradedConsensusState(context.Context, *clienttypes.QueryUpgradedConsensusStateRequest) (*clienttypes.QueryUpgradedConsensusStateResponse, error)
+}

--- a/modules/core/02-client/genesis.go
+++ b/modules/core/02-client/genesis.go
@@ -5,14 +5,14 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 )
 
 // InitGenesis initializes the ibc client submodule's state from a provided genesis
 // state.
-func InitGenesis(ctx sdk.Context, k keeper.Keeper, gs types.GenesisState) {
+func InitGenesis(ctx sdk.Context, k clientexported.ClientKeeper, gs types.GenesisState) {
 	k.SetParams(ctx, gs.Params)
 
 	// Set all client metadata first. This will allow client keeper to overwrite client and consensus state keys
@@ -54,7 +54,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, gs types.GenesisState) {
 // ExportGenesis returns the ibc client submodule's exported genesis.
 // NOTE: CreateLocalhost should always be false on export since a
 // created localhost will be included in the exported clients.
-func ExportGenesis(ctx sdk.Context, k keeper.Keeper) types.GenesisState {
+func ExportGenesis(ctx sdk.Context, k clientexported.ClientKeeper) types.GenesisState {
 	genClients := k.GetAllGenesisClients(ctx)
 	clientsMetadata, err := k.GetAllClientMetadata(ctx, genClients)
 	if err != nil {

--- a/modules/core/02-client/keeper/keeper.go
+++ b/modules/core/02-client/keeper/keeper.go
@@ -53,6 +53,14 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", "x/"+host.ModuleName+"/"+types.SubModuleName)
 }
 
+func (k Keeper) GetStoreKey() storetypes.StoreKey {
+	return k.storeKey
+}
+
+func (k Keeper) GetCdc() codec.BinaryCodec {
+	return k.cdc
+}
+
 // GenerateClientIdentifier returns the next client identifier.
 func (k Keeper) GenerateClientIdentifier(ctx sdk.Context, clientType string) string {
 	nextClientSeq := k.GetNextClientSequence(ctx)

--- a/modules/core/02-client/keeper/keeper_test.go
+++ b/modules/core/02-client/keeper/keeper_test.go
@@ -15,7 +15,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v5/modules/core/23-commitment/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
@@ -57,7 +57,7 @@ type KeeperTestSuite struct {
 
 	cdc            codec.Codec
 	ctx            sdk.Context
-	keeper         *keeper.Keeper
+	keeper         clientexported.ClientKeeper
 	consensusState *ibctmtypes.ConsensusState
 	header         *ibctmtypes.Header
 	valSet         *tmtypes.ValidatorSet
@@ -86,7 +86,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	suite.cdc = app.AppCodec()
 	suite.ctx = app.BaseApp.NewContext(isCheckTx, tmproto.Header{Height: height, ChainID: testClientID, Time: now2})
-	suite.keeper = &app.IBCKeeper.ClientKeeper
+	suite.keeper = app.IBCKeeper.ClientKeeper
 	suite.privVal = ibctestingmock.NewPV()
 
 	pubKey, err := suite.privVal.GetPubKey()

--- a/modules/core/02-client/keeper/migrations.go
+++ b/modules/core/02-client/keeper/migrations.go
@@ -3,16 +3,17 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	v100 "github.com/cosmos/ibc-go/v5/modules/core/02-client/legacy/v100"
 )
 
 // Migrator is a struct for handling in-place store migrations.
 type Migrator struct {
-	keeper Keeper
+	keeper clientexported.ClientKeeper
 }
 
 // NewMigrator returns a new Migrator.
-func NewMigrator(keeper Keeper) Migrator {
+func NewMigrator(keeper clientexported.ClientKeeper) Migrator {
 	return Migrator{keeper: keeper}
 }
 
@@ -23,5 +24,5 @@ func NewMigrator(keeper Keeper) Migrator {
 // - prunes expired tendermint consensus states
 // - adds iteration and processed height keys for unexpired tendermint consensus states
 func (m Migrator) Migrate1to2(ctx sdk.Context) error {
-	return v100.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc)
+	return v100.MigrateStore(ctx, m.keeper.GetStoreKey(), m.keeper.GetCdc())
 }

--- a/modules/core/02-client/proposal_handler.go
+++ b/modules/core/02-client/proposal_handler.go
@@ -5,12 +5,12 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/02-client/keeper"
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 )
 
 // NewClientProposalHandler defines the 02-client proposal handler
-func NewClientProposalHandler(k keeper.Keeper) govtypes.Handler {
+func NewClientProposalHandler(k clientexported.ClientKeeper) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
 		case *types.ClientUpdateProposal:

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
+	clientexported "github.com/cosmos/ibc-go/v5/modules/core/02-client/exported"
 	clientkeeper "github.com/cosmos/ibc-go/v5/modules/core/02-client/keeper"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	connectionkeeper "github.com/cosmos/ibc-go/v5/modules/core/03-connection/keeper"
@@ -28,7 +29,7 @@ type Keeper struct {
 
 	cdc codec.BinaryCodec
 
-	ClientKeeper     clientkeeper.Keeper
+	ClientKeeper     clientexported.ClientKeeper
 	ConnectionKeeper connectionkeeper.Keeper
 	ChannelKeeper    channelkeeper.Keeper
 	PortKeeper       portkeeper.Keeper


### PR DESCRIPTION
This PR provides the interface of the keeper for the IBC light client, and replaces the concrete client type with the interface for the IBC module's keeper.

This will allows us to drop in our own light client (with our own hooks and header verification logics) to the IBC module (i.e., `modules/core/`).

## Future works

- [ ] Hooks upon a light client with QC
- [ ] KVStore schema for ZoneConcierge
- [ ] Query API: return last checkpointed height of a given chain ID

