### PR TITLE
client: extend the keeper, add hooks, and leave space for injecting verification logics

### DIFF
--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -70,7 +70,7 @@ func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header e
 		txHash := tmhash.Sum(ctx.TxBytes())
 
 		// invoke hooks
-		ek.AfterHeaderWithQC(ctx, txHash, tmHeader)
+		ek.AfterHeaderWithValidCommit(ctx, txHash, tmHeader)
 	}
 
 	// TODO: inject our own verification rules

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
 // ExtendedKeeper is same as the original Keeper, except that
@@ -65,8 +66,11 @@ func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header e
 
 		// TODO: ensure the header has a valid QC
 
+		// get hash of the tx that includes this header
+		txHash := tmhash.Sum(ctx.TxBytes())
+
 		// invoke hooks
-		ek.AfterHeaderWithQC(ctx, tmHeader)
+		ek.AfterHeaderWithQC(ctx, txHash, tmHeader)
 	}
 
 	// TODO: inject our own verification rules

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -1,0 +1,74 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+)
+
+// ExtendedKeeper is same as the original Keeper, except that
+// - it provides hooks for notifying other modules on received headers
+// - it applies different verification rules on received headers
+//   (notably, choosing forks rather than freezing clients upon conflicted headers with QCS)
+type ExtendedKeeper struct {
+	Keeper
+	hooks ClientHooks
+}
+
+// NewKeeper creates a new NewKeeper instance
+func NewExtendedKeeper(cdc codec.BinaryCodec, key storetypes.StoreKey, paramSpace paramtypes.Subspace, sk types.StakingKeeper, uk types.UpgradeKeeper) ExtendedKeeper {
+	// set KeyTable if it has not already been set
+	if !paramSpace.HasKeyTable() {
+		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	k := Keeper{
+		storeKey:      key,
+		cdc:           cdc,
+		paramSpace:    paramSpace,
+		stakingKeeper: sk,
+		upgradeKeeper: uk,
+	}
+	return ExtendedKeeper{
+		Keeper: k,
+		hooks:  nil,
+	}
+}
+
+// SetHooks sets the hooks for ExtendedKeeper
+func (ek *ExtendedKeeper) SetHooks(ch ClientHooks) *ExtendedKeeper {
+	if ek.hooks != nil {
+		panic("cannot set hooks twice")
+	}
+	ek.hooks = ch
+
+	return ek
+}
+
+func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header exported.Header) error {
+	// header can be nil in the original IBC-Go design, e.g., in `BeginBlocker`
+	// Our logic only applies when header is not nil
+	if header != nil {
+		// asserting
+		// copied from `modules/light-clients/07-tendermint/types/update.go#L57`
+		tmHeader, ok := header.(*ibctmtypes.Header)
+		if !ok {
+			return sdkerrors.Wrapf(
+				types.ErrInvalidHeader, "expected type %T, got %T", &ibctmtypes.Header{}, header,
+			)
+		}
+
+		// TODO: ensure the header has a valid QC
+
+		// invoke hooks
+		ek.AfterHeaderWithQC(ctx, tmHeader)
+	}
+
+	// TODO: inject our own verification rules
+	return ek.Keeper.UpdateClient(ctx, clientID, header)
+}

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -21,7 +21,7 @@ type ExtendedKeeper struct {
 	hooks ClientHooks
 }
 
-// NewKeeper creates a new NewKeeper instance
+// NewExtendedKeeper creates a new NewExtendedKeeper instance
 func NewExtendedKeeper(cdc codec.BinaryCodec, key storetypes.StoreKey, paramSpace paramtypes.Subspace, sk types.StakingKeeper, uk types.UpgradeKeeper) ExtendedKeeper {
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -7,7 +7,7 @@ import (
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
+	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,17 +21,17 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	for i := range h {
-		h[i].AfterHeaderWithQC(ctx, txHash, header)
+		h[i].AfterHeaderWithValidCommit(ctx, txHash, header)
 	}
 }
 
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	if ek.hooks != nil {
-		ek.hooks.AfterHeaderWithQC(ctx, txHash, header)
+		ek.hooks.AfterHeaderWithValidCommit(ctx, txHash, header)
 	}
 }

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -1,0 +1,37 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+)
+
+// ClientHooks defines the hook interface for client
+type ClientHooks interface {
+	AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header)
+}
+
+// MultiClientHooks is a concrete implementation of ClientHooks
+// It allows other modules to hook onto client ExtendedKeeper
+var _ ClientHooks = &MultiClientHooks{}
+
+type MultiClientHooks []ClientHooks
+
+func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
+	return hooks
+}
+
+// invoke hooks in each keeper that hooks onto ExtendedKeeper
+func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+	for i := range h {
+		h[i].AfterHeaderWithQC(ctx, header)
+	}
+}
+
+// ensure ExtendedKeeper implements ClientHooks interfaces
+var _ ClientHooks = ExtendedKeeper{}
+
+func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+	if ek.hooks != nil {
+		ek.hooks.AfterHeaderWithQC(ctx, header)
+	}
+}

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -7,7 +7,7 @@ import (
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header)
+	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,17 +21,17 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	for i := range h {
-		h[i].AfterHeaderWithQC(ctx, header)
+		h[i].AfterHeaderWithQC(ctx, txHash, header)
 	}
 }
 
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	if ek.hooks != nil {
-		ek.hooks.AfterHeaderWithQC(ctx, header)
+		ek.hooks.AfterHeaderWithQC(ctx, txHash, header)
 	}
 }

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -63,7 +63,7 @@ func NewKeeper(
 		panic(fmt.Errorf("cannot initialize IBC keeper: empty scoped keeper"))
 	}
 
-	clientKeeper := clientkeeper.NewKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
+	clientKeeper := clientkeeper.NewExtendedKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
 	connectionKeeper := connectionkeeper.NewKeeper(cdc, key, paramSpace, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)


### PR DESCRIPTION
Fixes [BM-248](https://babylon-chain.atlassian.net/browse/BM-248)

This PR provides `ExtendedKeeper`, which is an extension of the original Keeper for the light client module. It serves as a drop-in replacement of the original light client keeper for the IBC module.

In addition to the original keeper, `ExtendedKeeper` provides hooks for notifications of new headers, and allows to tweak verification logics of headers. The concrete verification logics will be implemented in a subsequent PR.