### PR TITLE
light client: intercept headers, inject verification rules, and trigger hooks

### DIFF
--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -153,7 +153,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			conflictConsState := updateHeader.ConsensusState()
 			conflictConsState.Root = commitmenttypes.NewMerkleRoot([]byte("conflicting apphash"))
 			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainA.GetContext(), clientID, updateHeader.GetHeight(), conflictConsState)
-		}, true, true},
+		}, false, false}, // Babylon modification: fork headers are rejected before being passed to ClientState
 		{"misbehaviour detection: monotonic time violation", func() {
 			clientState := path.EndpointA.GetClientState().(*ibctmtypes.ClientState)
 			clientID := path.EndpointA.ClientID
@@ -175,7 +175,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), clientID, clientState)
 
 			updateHeader = createFutureUpdateFn(trustedHeight)
-		}, true, true},
+		}, false, false}, // Babylon modification: non-monotonic headers are rejected before being passed to ClientState
 		{"client state not found", func() {
 			updateHeader = createFutureUpdateFn(path.EndpointA.GetClientState().GetLatestHeight().(types.Height))
 

--- a/modules/core/02-client/keeper/client_test.go
+++ b/modules/core/02-client/keeper/client_test.go
@@ -153,7 +153,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			conflictConsState := updateHeader.ConsensusState()
 			conflictConsState.Root = commitmenttypes.NewMerkleRoot([]byte("conflicting apphash"))
 			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientConsensusState(suite.chainA.GetContext(), clientID, updateHeader.GetHeight(), conflictConsState)
-		}, false, false}, // Babylon modification: fork headers are rejected before being passed to ClientState
+		}, true, true},
 		{"misbehaviour detection: monotonic time violation", func() {
 			clientState := path.EndpointA.GetClientState().(*ibctmtypes.ClientState)
 			clientID := path.EndpointA.ClientID
@@ -175,7 +175,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			suite.chainA.App.GetIBCKeeper().ClientKeeper.SetClientState(suite.chainA.GetContext(), clientID, clientState)
 
 			updateHeader = createFutureUpdateFn(trustedHeight)
-		}, false, false}, // Babylon modification: non-monotonic headers are rejected before being passed to ClientState
+		}, true, true},
 		{"client state not found", func() {
 			updateHeader = createFutureUpdateFn(path.EndpointA.GetClientState().GetLatestHeight().(types.Height))
 

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -70,7 +70,7 @@ func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header e
 		txHash := tmhash.Sum(ctx.TxBytes())
 
 		// invoke hooks
-		ek.AfterHeaderWithQC(ctx, txHash, tmHeader)
+		ek.AfterHeaderWithValidCommit(ctx, txHash, tmHeader)
 	}
 
 	// TODO: inject our own verification rules

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
 // ExtendedKeeper is same as the original Keeper, except that
@@ -65,8 +66,11 @@ func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header e
 
 		// TODO: ensure the header has a valid QC
 
+		// get hash of the tx that includes this header
+		txHash := tmhash.Sum(ctx.TxBytes())
+
 		// invoke hooks
-		ek.AfterHeaderWithQC(ctx, tmHeader)
+		ek.AfterHeaderWithQC(ctx, txHash, tmHeader)
 	}
 
 	// TODO: inject our own verification rules

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -1,0 +1,74 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+)
+
+// ExtendedKeeper is same as the original Keeper, except that
+// - it provides hooks for notifying other modules on received headers
+// - it applies different verification rules on received headers
+//   (notably, choosing forks rather than freezing clients upon conflicted headers with QCS)
+type ExtendedKeeper struct {
+	Keeper
+	hooks ClientHooks
+}
+
+// NewKeeper creates a new NewKeeper instance
+func NewExtendedKeeper(cdc codec.BinaryCodec, key storetypes.StoreKey, paramSpace paramtypes.Subspace, sk types.StakingKeeper, uk types.UpgradeKeeper) ExtendedKeeper {
+	// set KeyTable if it has not already been set
+	if !paramSpace.HasKeyTable() {
+		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	k := Keeper{
+		storeKey:      key,
+		cdc:           cdc,
+		paramSpace:    paramSpace,
+		stakingKeeper: sk,
+		upgradeKeeper: uk,
+	}
+	return ExtendedKeeper{
+		Keeper: k,
+		hooks:  nil,
+	}
+}
+
+// SetHooks sets the hooks for ExtendedKeeper
+func (ek *ExtendedKeeper) SetHooks(ch ClientHooks) *ExtendedKeeper {
+	if ek.hooks != nil {
+		panic("cannot set hooks twice")
+	}
+	ek.hooks = ch
+
+	return ek
+}
+
+func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header exported.Header) error {
+	// header can be nil in the original IBC-Go design, e.g., in `BeginBlocker`
+	// Our logic only applies when header is not nil
+	if header != nil {
+		// asserting
+		// copied from `modules/light-clients/07-tendermint/types/update.go#L57`
+		tmHeader, ok := header.(*ibctmtypes.Header)
+		if !ok {
+			return sdkerrors.Wrapf(
+				types.ErrInvalidHeader, "expected type %T, got %T", &ibctmtypes.Header{}, header,
+			)
+		}
+
+		// TODO: ensure the header has a valid QC
+
+		// invoke hooks
+		ek.AfterHeaderWithQC(ctx, tmHeader)
+	}
+
+	// TODO: inject our own verification rules
+	return ek.Keeper.UpdateClient(ctx, clientID, header)
+}

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -1,15 +1,21 @@
 package keeper
 
 import (
+	"bytes"
+	"reflect"
+	"time"
+
+	sdkerrors "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
 	"github.com/tendermint/tendermint/crypto/tmhash"
+	"github.com/tendermint/tendermint/light"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // ExtendedKeeper is same as the original Keeper, except that
@@ -64,15 +70,206 @@ func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header e
 			)
 		}
 
-		// TODO: ensure the header has a valid QC
+		// apply all verification rules to the header
+		err := ek.checkHeader(ctx, clientID, tmHeader)
 
-		// get hash of the tx that includes this header
-		txHash := tmhash.Sum(ctx.TxBytes())
+		// good header, timestamp it on the canonical chain indexer
+		if err == nil {
+			txHash := tmhash.Sum(ctx.TxBytes())                // get hash of the tx that includes this header
+			ek.AfterHeaderWithQC(ctx, txHash, tmHeader, false) // invoke hooks to notify ZoneConcierge to timestamp this header
+		}
 
-		// invoke hooks
-		ek.AfterHeaderWithQC(ctx, txHash, tmHeader)
+		// The header has a QC but {is on a fork, its timestamp is not monotonic}, timestamp it on the fork indexer, and return to avoid freezing the light client
+		// These two errors only happen upon dishonest majority
+		if sdkerrors.IsOf(err, types.ErrForkedHeaderWithQC, types.ErrHeaderNonMonotonicTimestamp) {
+			ctx.Logger().Debug("received a header that has QC but is on a fork")
+			txHash := tmhash.Sum(ctx.TxBytes())
+			ek.AfterHeaderWithQC(ctx, txHash, tmHeader, true)
+			return err
+		}
+
+		// Upon other errors (that happen under honest majority), return error without timestamping it
+		if err != nil {
+			return err
+		}
 	}
 
-	// TODO: inject our own verification rules
+	// the header has a valid QC and is extending canonical chain
+	// follow the original verification rules to update client state
 	return ek.Keeper.UpdateClient(ctx, clientID, header)
+}
+
+// checkHeader checks
+// - if a header is on fork,
+// - if a header has a valid QC or not, and
+// - other miscellaneous verification rules
+// It is essentially `CheckHeaderAndUpdateState` without updating the state
+// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/core/02-client/keeper/client.go#L60)
+func (ek ExtendedKeeper) checkHeader(ctx sdk.Context, clientID string, tmHeader *ibctmtypes.Header) error {
+	clientState, found := ek.GetClientState(ctx, clientID)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)
+	}
+
+	clientStore := ek.ClientStore(ctx, clientID)
+	if status := clientState.Status(ctx, clientStore, ek.cdc); status != exported.Active {
+		return sdkerrors.Wrapf(types.ErrClientNotActive, "cannot update client (%s) with status %s", clientID, status)
+	}
+
+	// Check if the header is on a fork
+	// If the consensus state exists, and it does not match this header, then this header is on a fork
+	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L63-L77)
+	isOnFork := false
+	conflictingState, _ := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
+	if conflictingState != nil {
+		if !reflect.DeepEqual(conflictingState, tmHeader.ConsensusState()) {
+			isOnFork = true
+		}
+	}
+
+	// Check if the header can pass all verification rules, including the QC
+	// Note that the first header on a fork can also be valid
+	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L79-L89)
+	trustedConsState, err := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.TrustedHeight)
+	if err != nil {
+		return sdkerrors.Wrapf(
+			err, "could not get consensus state from clientstore at TrustedHeight: %s", tmHeader.TrustedHeight,
+		)
+	}
+	// asserting clientState to that of Tendermint client
+	cs, ok := clientState.(*ibctmtypes.ClientState)
+	if !ok {
+		return sdkerrors.Wrapf(
+			types.ErrFailedClientStateVerification, "expected type %T, got %T", &ibctmtypes.ClientState{}, clientState,
+		)
+	}
+	if err := checkValidity(cs, trustedConsState, tmHeader, ctx.BlockTime()); err != nil {
+		return err
+	}
+
+	// this header passes QC verifications but is on a fork
+	if isOnFork {
+		return types.ErrForkedHeaderWithQC
+	}
+
+	consState := tmHeader.ConsensusState()
+	// Check that consensus state timestamps are monotonic
+	prevCons, prevOk := ibctmtypes.GetPreviousConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
+	nextCons, nextOk := ibctmtypes.GetNextConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
+	// if previous consensus state exists, check consensus state time is greater than previous consensus state time
+	// if previous consensus state is not before current consensus state, freeze the client and return.
+	if prevOk && !prevCons.Timestamp.Before(consState.Timestamp) {
+		return types.ErrHeaderNonMonotonicTimestamp
+	}
+	// if next consensus state exists, check consensus state time is less than next consensus state time
+	// if next consensus state is not after current consensus state, freeze the client and return.
+	if nextOk && !nextCons.Timestamp.After(consState.Timestamp) {
+		return types.ErrHeaderNonMonotonicTimestamp
+	}
+
+	return nil
+}
+
+// checkValidity checks if the Tendermint header is valid.
+// CONTRACT: consState.Height == header.TrustedHeight
+// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L168-L248)
+func checkValidity(
+	clientState *ibctmtypes.ClientState, consState *ibctmtypes.ConsensusState,
+	header *ibctmtypes.Header, currentTimestamp time.Time,
+) error {
+	if err := checkTrustedHeader(header, consState); err != nil {
+		return err
+	}
+
+	// UpdateClient only accepts updates with a header at the same revision
+	// as the trusted consensus state
+	if header.GetHeight().GetRevisionNumber() != header.TrustedHeight.RevisionNumber {
+		return sdkerrors.Wrapf(
+			ibctmtypes.ErrInvalidHeaderHeight,
+			"header height revision %d does not match trusted header revision %d",
+			header.GetHeight().GetRevisionNumber(), header.TrustedHeight.RevisionNumber,
+		)
+	}
+
+	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
+	if err != nil {
+		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
+	}
+
+	tmSignedHeader, err := tmtypes.SignedHeaderFromProto(header.SignedHeader)
+	if err != nil {
+		return sdkerrors.Wrap(err, "signed header in not tendermint signed header type")
+	}
+
+	tmValidatorSet, err := tmtypes.ValidatorSetFromProto(header.ValidatorSet)
+	if err != nil {
+		return sdkerrors.Wrap(err, "validator set in not tendermint validator set type")
+	}
+
+	// assert header height is newer than consensus state
+	if header.GetHeight().LTE(header.TrustedHeight) {
+		return sdkerrors.Wrapf(
+			types.ErrInvalidHeader,
+			"header height ≤ consensus state height (%s ≤ %s)", header.GetHeight(), header.TrustedHeight,
+		)
+	}
+
+	chainID := clientState.GetChainID()
+	// If chainID is in revision format, then set revision number of chainID with the revision number
+	// of the header we are verifying
+	// This is useful if the update is at a previous revision rather than an update to the latest revision
+	// of the client.
+	// The chainID must be set correctly for the previous revision before attempting verification.
+	// Updates for previous revisions are not supported if the chainID is not in revision format.
+	if types.IsRevisionFormat(chainID) {
+		chainID, _ = types.SetRevisionNumber(chainID, header.GetHeight().GetRevisionNumber())
+	}
+
+	// Construct a trusted header using the fields in consensus state
+	// Only Height, Time, and NextValidatorsHash are necessary for verification
+	trustedHeader := tmtypes.Header{
+		ChainID:            chainID,
+		Height:             int64(header.TrustedHeight.RevisionHeight),
+		Time:               consState.Timestamp,
+		NextValidatorsHash: consState.NextValidatorsHash,
+	}
+	signedHeader := tmtypes.SignedHeader{
+		Header: &trustedHeader,
+	}
+
+	// Verify next header with the passed-in trustedVals
+	// - asserts trusting period not passed
+	// - assert header timestamp is not past the trusting period
+	// - assert header timestamp is past latest stored consensus state timestamp
+	// - assert that a TrustLevel proportion of TrustedValidators signed new Commit
+	err = light.Verify(
+		&signedHeader,
+		tmTrustedValidators, tmSignedHeader, tmValidatorSet,
+		clientState.TrustingPeriod, currentTimestamp, clientState.MaxClockDrift, clientState.TrustLevel.ToTendermint(),
+	)
+	if err != nil {
+		return sdkerrors.Wrap(err, "failed to verify header")
+	}
+	return nil
+}
+
+// checkTrustedHeader checks that consensus state matches trusted fields of Header
+// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L148-L166)
+func checkTrustedHeader(header *ibctmtypes.Header, consState *ibctmtypes.ConsensusState) error {
+	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
+	if err != nil {
+		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
+	}
+
+	// assert that trustedVals is NextValidators of last trusted header
+	// to do this, we check that trustedVals.Hash() == consState.NextValidatorsHash
+	tvalHash := tmTrustedValidators.Hash()
+	if !bytes.Equal(consState.NextValidatorsHash, tvalHash) {
+		return sdkerrors.Wrapf(
+			ibctmtypes.ErrInvalidValidatorSet,
+			"trusted validators %s, does not hash to latest trusted validators. Expected: %X, got: %X",
+			header.TrustedValidators, consState.NextValidatorsHash, tvalHash,
+		)
+	}
+	return nil
 }

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -21,7 +21,7 @@ type ExtendedKeeper struct {
 	hooks ClientHooks
 }
 
-// NewKeeper creates a new NewKeeper instance
+// NewExtendedKeeper creates a new NewExtendedKeeper instance
 func NewExtendedKeeper(cdc codec.BinaryCodec, key storetypes.StoreKey, paramSpace paramtypes.Subspace, sk types.StakingKeeper, uk types.UpgradeKeeper) ExtendedKeeper {
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -7,7 +7,7 @@ import (
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
+	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,17 +21,17 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
 	for i := range h {
-		h[i].AfterHeaderWithQC(ctx, txHash, header)
+		h[i].AfterHeaderWithQC(ctx, txHash, header, isOnFork)
 	}
 }
 
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
 	if ek.hooks != nil {
-		ek.hooks.AfterHeaderWithQC(ctx, txHash, header)
+		ek.hooks.AfterHeaderWithQC(ctx, txHash, header, isOnFork)
 	}
 }

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -7,7 +7,7 @@ import (
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
+	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,17 +21,17 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	for i := range h {
-		h[i].AfterHeaderWithQC(ctx, txHash, header)
+		h[i].AfterHeaderWithValidCommit(ctx, txHash, header)
 	}
 }
 
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
+func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	if ek.hooks != nil {
-		ek.hooks.AfterHeaderWithQC(ctx, txHash, header)
+		ek.hooks.AfterHeaderWithValidCommit(ctx, txHash, header)
 	}
 }

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -1,0 +1,37 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
+)
+
+// ClientHooks defines the hook interface for client
+type ClientHooks interface {
+	AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header)
+}
+
+// MultiClientHooks is a concrete implementation of ClientHooks
+// It allows other modules to hook onto client ExtendedKeeper
+var _ ClientHooks = &MultiClientHooks{}
+
+type MultiClientHooks []ClientHooks
+
+func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
+	return hooks
+}
+
+// invoke hooks in each keeper that hooks onto ExtendedKeeper
+func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+	for i := range h {
+		h[i].AfterHeaderWithQC(ctx, header)
+	}
+}
+
+// ensure ExtendedKeeper implements ClientHooks interfaces
+var _ ClientHooks = ExtendedKeeper{}
+
+func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+	if ek.hooks != nil {
+		ek.hooks.AfterHeaderWithQC(ctx, header)
+	}
+}

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -7,7 +7,7 @@ import (
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header)
+	AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,17 +21,17 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+func (h MultiClientHooks) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	for i := range h {
-		h[i].AfterHeaderWithQC(ctx, header)
+		h[i].AfterHeaderWithQC(ctx, txHash, header)
 	}
 }
 
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, header *ibctmtypes.Header) {
+func (ek ExtendedKeeper) AfterHeaderWithQC(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header) {
 	if ek.hooks != nil {
-		ek.hooks.AfterHeaderWithQC(ctx, header)
+		ek.hooks.AfterHeaderWithQC(ctx, txHash, header)
 	}
 }

--- a/modules/core/02-client/types/errors.go
+++ b/modules/core/02-client/types/errors.go
@@ -34,4 +34,7 @@ var (
 	ErrInvalidSubstitute                      = sdkerrors.Register(SubModuleName, 27, "invalid client state substitute")
 	ErrInvalidUpgradeProposal                 = sdkerrors.Register(SubModuleName, 28, "invalid upgrade proposal")
 	ErrClientNotActive                        = sdkerrors.Register(SubModuleName, 29, "client is not active")
+	// dishonest majority errors in Babylon
+	ErrForkedHeaderWithQC          = sdkerrors.Register(SubModuleName, 30, "header has a valid QC but is on a fork")
+	ErrHeaderNonMonotonicTimestamp = sdkerrors.Register(SubModuleName, 31, "header has a valid QC but its timestamp is not monotomic")
 )

--- a/modules/core/02-client/types/errors.go
+++ b/modules/core/02-client/types/errors.go
@@ -35,6 +35,6 @@ var (
 	ErrInvalidUpgradeProposal                 = sdkerrors.Register(SubModuleName, 28, "invalid upgrade proposal")
 	ErrClientNotActive                        = sdkerrors.Register(SubModuleName, 29, "client is not active")
 	// dishonest majority errors in Babylon
-	ErrForkedHeaderWithQC          = sdkerrors.Register(SubModuleName, 30, "header has a valid QC but is on a fork")
+	ErrForkedHeaderWithValidCommit = sdkerrors.Register(SubModuleName, 30, "header has a valid QC but is on a fork")
 	ErrHeaderNonMonotonicTimestamp = sdkerrors.Register(SubModuleName, 31, "header has a valid QC but its timestamp is not monotomic")
 )

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -63,7 +63,7 @@ func NewKeeper(
 		panic(fmt.Errorf("cannot initialize IBC keeper: empty scoped keeper"))
 	}
 
-	clientKeeper := clientkeeper.NewKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
+	clientKeeper := clientkeeper.NewExtendedKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
 	connectionKeeper := connectionkeeper.NewKeeper(cdc, key, paramSpace, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)

--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -63,7 +63,7 @@ func NewKeeper(
 		panic(fmt.Errorf("cannot initialize IBC keeper: empty scoped keeper"))
 	}
 
-	clientKeeper := clientkeeper.NewExtendedKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
+	clientKeeper := clientkeeper.NewKeeper(cdc, key, paramSpace, stakingKeeper, upgradeKeeper)
 	connectionKeeper := connectionkeeper.NewKeeper(cdc, key, paramSpace, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)


### PR DESCRIPTION
Fixes [BM-253](https://babylon-chain.atlassian.net/browse/BM-253)

This PR implements the functionality of intercepting headers, injecting our own verification rules, and triggering hooks to notify ZoneConcierge for timestamping. The implementation largely porting https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go, except that

- We distinguish between errors that happen upon dishonest majority (which will freeze the client) and normal errors. There are only two types of errors that happen under dishonest majority
	- Header that has a QC but is on a fork
	- Header that has a QC but its timestamp is not between the prior header's timestamp and the later header's timestamp
- Before the original parsing logics in `CheckHeaderAndUpdateState`, we apply all verification rules and do the following things for the header:
	- If the header passes all verifications, timestamp it, and pass it to `CheckHeaderAndUpdateState` normally
	- If the header triggers a dishonest majority error, timestamp it with a label denoting forks, and return directly (to avoid freezing the client)
	- If the header triggers a normal error, return directly without timestamping