### PR TITLE
Generalize lc callback to multiple clients

### DIFF
--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -1,21 +1,16 @@
 package keeper
 
 import (
-	"bytes"
-	"reflect"
-	"time"
-
 	sdkerrors "cosmossdk.io/errors"
+	metrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/exported"
-	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint"
 	"github.com/tendermint/tendermint/crypto/tmhash"
-	"github.com/tendermint/tendermint/light"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // ExtendedKeeper is same as the original Keeper, except that
@@ -57,242 +52,80 @@ func (ek *ExtendedKeeper) SetHooks(ch ClientHooks) *ExtendedKeeper {
 	return ek
 }
 
-// UpdateClient applies all verification rules on the header before executing the original UpdateClient() logic.
-// There are three possible outcomes after the verification:
-// 1. All verifications are passed: timestamp the header, pass the header to original UpdateClient()
-// 2. Verification fails with errors that only happen upon dishonest majority: timestamp the header, don't pass the header to original UpdateClient()
-// 3. Verification fails with normal errors: don't timestamp the header, don't pass the header to original UpdateClient()
-func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header exported.ClientMessage) error {
-	// check if the client type is 07-tendermint
-	clientState, found := ek.GetClientState(ctx, clientID)
-	if !found {
-		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)
-	}
-	_, isTmClient := clientState.(*ibctmtypes.ClientState)
-
-	// Our logic only applies when
-	// - header is not nil (header can be nil in the original IBC-Go design, e.g., in `BeginBlocker`)
-	// - the client type is 07-tendermint (IBC-Go only supports 07-tendermint client at the moment)
-	if header == nil {
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	}
-
-	// TODO to support wasm client, we obviously need to do something different here.
-	// whole callback AfterHeaderWithValidCommit, must be generalized to support
-	// other client types, not only tendermint.
-	if !isTmClient {
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	}
-
-	switch msg := header.(type) {
-	case *ibctmtypes.Header:
-		// TODO in ibc-go v7 this whole verification was moved to seprarate function
-		// clientState.CheckForMisbehaviour. Probably we can do a lot of simplifications
-		// here.
-		err := ek.checkHeader(ctx, clientID, msg)
-
-		// good header, timestamp it on the canonical chain indexer
-		if err == nil {
-			txHash := tmhash.Sum(ctx.TxBytes())                    // get hash of the tx that includes this header
-			ek.AfterHeaderWithValidCommit(ctx, txHash, msg, false) // invoke hooks to notify ZoneConcierge to timestamp this header
-		}
-
-		// The header has a QC but {is on a fork, its timestamp is not monotonic}, timestamp it on the fork indexer, and return to avoid freezing the light client
-		// These two errors only happen upon dishonest majority
-		if sdkerrors.IsOf(err, types.ErrForkedHeaderWithValidCommit, types.ErrHeaderNonMonotonicTimestamp) {
-			ctx.Logger().Debug("received a header that has QC but is on a fork")
-			txHash := tmhash.Sum(ctx.TxBytes())
-			ek.AfterHeaderWithValidCommit(ctx, txHash, msg, true)
-			return err
-		}
-
-		// Upon other errors (that happen under honest majority), return error without timestamping it
-		if err != nil {
-			return err
-		}
-
-		// the header has a valid QC and is extending canonical chain
-		// follow the original verification rules to update client state
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	case *ibctmtypes.Misbehaviour:
-		// on Misbehaviour,just forward to standard client logic
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	default:
-		return types.ErrInvalidClientType
-	}
-}
-
-// checkHeader checks
-// - if a header is on fork,
-// - if a header has a valid QC or not, and
-// - other miscellaneous verification rules
-// It is essentially `CheckHeaderAndUpdateState` without updating the state
-// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/core/02-client/keeper/client.go#L60)
-func (ek ExtendedKeeper) checkHeader(ctx sdk.Context, clientID string, tmHeader *ibctmtypes.Header) error {
+func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, clientMsg exported.ClientMessage) error {
 	clientState, found := ek.GetClientState(ctx, clientID)
 	if !found {
 		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)
 	}
 
 	clientStore := ek.ClientStore(ctx, clientID)
+
 	if status := clientState.Status(ctx, clientStore, ek.cdc); status != exported.Active {
 		return sdkerrors.Wrapf(types.ErrClientNotActive, "cannot update client (%s) with status %s", clientID, status)
 	}
 
-	// Check if the header is on a fork
-	// If the consensus state exists, and it does not match this header, then this header is on a fork
-	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L63-L77)
-	isOnFork := false
-	prevConsState, _ := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	if prevConsState != nil {
-		if !reflect.DeepEqual(prevConsState, tmHeader.ConsensusState()) {
-			isOnFork = true
-		}
-	}
-
-	// Check if the header can pass all verification rules, including the QC
-	// Note that the first header on a fork can also be valid
-	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L79-L89)
-	trustedConsState, exists := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.TrustedHeight)
-	if !exists {
-		return sdkerrors.Wrapf(
-			types.ErrConsensusStateNotFound, "could not get consensus state from clientstore at TrustedHeight: %s", tmHeader.TrustedHeight,
-		)
-	}
-	// asserting clientState to that of Tendermint client
-	cs, ok := clientState.(*ibctmtypes.ClientState)
-	if !ok {
-		return sdkerrors.Wrapf(
-			types.ErrFailedClientStateVerification, "expected type %T, got %T", &ibctmtypes.ClientState{}, clientState,
-		)
-	}
-	if err := checkValidity(cs, trustedConsState, tmHeader, ctx.BlockTime()); err != nil {
+	if err := clientState.VerifyClientMessage(ctx, ek.cdc, clientStore, clientMsg); err != nil {
 		return err
 	}
 
-	// this header passes QC verifications but is on a fork
-	if isOnFork {
-		return types.ErrForkedHeaderWithValidCommit
+	foundMisbehaviour := clientState.CheckForMisbehaviour(ctx, ek.cdc, clientStore, clientMsg)
+
+	header, isHeader := clientMsg.(exported.LCHeader)
+
+	// First difference in comparission to standard keeper update client
+	if foundMisbehaviour && isHeader {
+		// this is header and we foundMisbehaviour. Depending on lc client it can
+		// mean many things in case of tendermint it means either invalid timestamp
+		// or conflicting header. Do not update state and do not freeze light client
+		ctx.Logger().Debug("received a header that has QC but is on a fork")
+		txHash := tmhash.Sum(ctx.TxBytes())
+		ek.AfterHeaderWithValidCommit(ctx, txHash, header, true)
+		return nil
 	}
 
-	consState := tmHeader.ConsensusState()
-	// Check that consensus state timestamps are monotonic
-	prevCons, prevOk := ibctmtypes.GetPreviousConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	nextCons, nextOk := ibctmtypes.GetNextConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	// if previous consensus state exists, check consensus state time is greater than previous consensus state time
-	// if previous consensus state is not before current consensus state, freeze the client and return.
-	if prevOk && !prevCons.Timestamp.Before(consState.Timestamp) {
-		return types.ErrHeaderNonMonotonicTimestamp
-	}
-	// if next consensus state exists, check consensus state time is less than next consensus state time
-	// if next consensus state is not after current consensus state, freeze the client and return.
-	if nextOk && !nextCons.Timestamp.After(consState.Timestamp) {
-		return types.ErrHeaderNonMonotonicTimestamp
-	}
+	if foundMisbehaviour {
+		clientState.UpdateStateOnMisbehaviour(ctx, ek.cdc, clientStore, clientMsg)
 
-	return nil
-}
+		ek.Logger(ctx).Info("client frozen due to misbehaviour", "client-id", clientID)
 
-// checkValidity checks if the Tendermint header is valid.
-// CONTRACT: consState.Height == header.TrustedHeight
-// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L168-L248)
-func checkValidity(
-	clientState *ibctmtypes.ClientState, consState *ibctmtypes.ConsensusState,
-	header *ibctmtypes.Header, currentTimestamp time.Time,
-) error {
-	if err := checkTrustedHeader(header, consState); err != nil {
-		return err
-	}
-
-	// UpdateClient only accepts updates with a header at the same revision
-	// as the trusted consensus state
-	if header.GetHeight().GetRevisionNumber() != header.TrustedHeight.RevisionNumber {
-		return sdkerrors.Wrapf(
-			ibctmtypes.ErrInvalidHeaderHeight,
-			"header height revision %d does not match trusted header revision %d",
-			header.GetHeight().GetRevisionNumber(), header.TrustedHeight.RevisionNumber,
+		defer telemetry.IncrCounterWithLabels(
+			[]string{"ibc", "client", "misbehaviour"},
+			1,
+			[]metrics.Label{
+				telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+				telemetry.NewLabel(types.LabelClientID, clientID),
+				telemetry.NewLabel(types.LabelMsgType, "update"),
+			},
 		)
+
+		EmitSubmitMisbehaviourEvent(ctx, clientID, clientState)
+
+		return nil
 	}
 
-	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
-	if err != nil {
-		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
+	// Second difference in comparission to standard keeper update client
+	// this valid header without any misbehaviours time stamp it
+	if isHeader {
+		txHash := tmhash.Sum(ctx.TxBytes())
+		ek.AfterHeaderWithValidCommit(ctx, txHash, header, false)
 	}
 
-	tmSignedHeader, err := tmtypes.SignedHeaderFromProto(header.SignedHeader)
-	if err != nil {
-		return sdkerrors.Wrap(err, "signed header in not tendermint signed header type")
-	}
+	consensusHeights := clientState.UpdateState(ctx, ek.cdc, clientStore, clientMsg)
 
-	tmValidatorSet, err := tmtypes.ValidatorSetFromProto(header.ValidatorSet)
-	if err != nil {
-		return sdkerrors.Wrap(err, "validator set in not tendermint validator set type")
-	}
+	ek.Logger(ctx).Info("client state updated", "client-id", clientID, "heights", consensusHeights)
 
-	// assert header height is newer than consensus state
-	if header.GetHeight().LTE(header.TrustedHeight) {
-		return sdkerrors.Wrapf(
-			types.ErrInvalidHeader,
-			"header height ≤ consensus state height (%s ≤ %s)", header.GetHeight(), header.TrustedHeight,
-		)
-	}
-
-	chainID := clientState.GetChainID()
-	// If chainID is in revision format, then set revision number of chainID with the revision number
-	// of the header we are verifying
-	// This is useful if the update is at a previous revision rather than an update to the latest revision
-	// of the client.
-	// The chainID must be set correctly for the previous revision before attempting verification.
-	// Updates for previous revisions are not supported if the chainID is not in revision format.
-	if types.IsRevisionFormat(chainID) {
-		chainID, _ = types.SetRevisionNumber(chainID, header.GetHeight().GetRevisionNumber())
-	}
-
-	// Construct a trusted header using the fields in consensus state
-	// Only Height, Time, and NextValidatorsHash are necessary for verification
-	trustedHeader := tmtypes.Header{
-		ChainID:            chainID,
-		Height:             int64(header.TrustedHeight.RevisionHeight),
-		Time:               consState.Timestamp,
-		NextValidatorsHash: consState.NextValidatorsHash,
-	}
-	signedHeader := tmtypes.SignedHeader{
-		Header: &trustedHeader,
-	}
-
-	// Verify next header with the passed-in trustedVals
-	// - asserts trusting period not passed
-	// - assert header timestamp is not past the trusting period
-	// - assert header timestamp is past latest stored consensus state timestamp
-	// - assert that a TrustLevel proportion of TrustedValidators signed new Commit
-	err = light.Verify(
-		&signedHeader,
-		tmTrustedValidators, tmSignedHeader, tmValidatorSet,
-		clientState.TrustingPeriod, currentTimestamp, clientState.MaxClockDrift, clientState.TrustLevel.ToTendermint(),
+	defer telemetry.IncrCounterWithLabels(
+		[]string{"ibc", "client", "update"},
+		1,
+		[]metrics.Label{
+			telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+			telemetry.NewLabel(types.LabelClientID, clientID),
+			telemetry.NewLabel(types.LabelUpdateType, "msg"),
+		},
 	)
-	if err != nil {
-		return sdkerrors.Wrap(err, "failed to verify header")
-	}
-	return nil
-}
 
-// checkTrustedHeader checks that consensus state matches trusted fields of Header
-// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L148-L166)
-func checkTrustedHeader(header *ibctmtypes.Header, consState *ibctmtypes.ConsensusState) error {
-	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
-	if err != nil {
-		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
-	}
+	// emitting events in the keeper emits for both begin block and handler client updates
+	EmitUpdateClientEvent(ctx, clientID, clientState.ClientType(), consensusHeights, ek.cdc, clientMsg)
 
-	// assert that trustedVals is NextValidators of last trusted header
-	// to do this, we check that trustedVals.Hash() == consState.NextValidatorsHash
-	tvalHash := tmTrustedValidators.Hash()
-	if !bytes.Equal(consState.NextValidatorsHash, tvalHash) {
-		return sdkerrors.Wrapf(
-			ibctmtypes.ErrInvalidValidatorSet,
-			"trusted validators %s, does not hash to latest trusted validators. Expected: %X, got: %X",
-			header.TrustedValidators, consState.NextValidatorsHash, tvalHash,
-		)
-	}
 	return nil
 }

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -2,12 +2,12 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint"
+	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 )
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool)
+	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header exported.LCHeader, isOnFork bool)
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,7 +21,7 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
+func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header exported.LCHeader, isOnFork bool) {
 	for i := range h {
 		h[i].AfterHeaderWithValidCommit(ctx, txHash, header, isOnFork)
 	}
@@ -30,7 +30,7 @@ func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []b
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
+func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header exported.LCHeader, isOnFork bool) {
 	if ek.hooks != nil {
 		ek.hooks.AfterHeaderWithValidCommit(ctx, txHash, header, isOnFork)
 	}

--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -155,6 +155,11 @@ type ClientMessage interface {
 	ValidateBasic() error
 }
 
+type LCHeader interface {
+	ClientMessage
+	HeaderHeight() Height
+}
+
 // Height is a wrapper interface over clienttypes.Height
 // all clients must use the concrete implementation in types
 type Height interface {

--- a/modules/light-clients/06-solomachine/header.go
+++ b/modules/light-clients/06-solomachine/header.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ exported.ClientMessage = &Header{}
+var _ exported.LCHeader = &Header{}
 
 // ClientType defines that the Header is a Solo Machine.
 func (Header) ClientType() string {
@@ -58,4 +59,9 @@ func (h Header) ValidateBasic() error {
 	}
 
 	return nil
+}
+
+func (h Header) HeaderHeight() exported.Height {
+	// for solo machine height is actually sequence number
+	return clienttypes.NewHeight(0, h.Sequence)
 }

--- a/modules/light-clients/07-tendermint/header.go
+++ b/modules/light-clients/07-tendermint/header.go
@@ -13,6 +13,8 @@ import (
 )
 
 var _ exported.ClientMessage = &Header{}
+var _ exported.LCHeader = &Header{}
+
 
 // ConsensusState returns the updated consensus state associated with the header
 func (h Header) ConsensusState() *ConsensusState {
@@ -79,4 +81,8 @@ func (h Header) ValidateBasic() error {
 		return sdkerrors.Wrap(clienttypes.ErrInvalidHeader, "validator set does not match hash")
 	}
 	return nil
+}
+
+func (h Header) HeaderHeight() exported.Height {
+	return h.GetHeight()
 }

--- a/modules/light-clients/10-wasm/header.go
+++ b/modules/light-clients/10-wasm/header.go
@@ -7,6 +7,7 @@ import (
 )
 
 var _ exported.ClientMessage = &Header{}
+var _ exported.LCHeader = &Header{}
 
 func (m Header) ClientType() string {
 	return exported.Wasm
@@ -18,4 +19,10 @@ func (m Header) ValidateBasic() error {
 	}
 
 	return nil
+}
+
+func (h Header) HeaderHeight() exported.Height {
+	// TODO what exactly is this wasm header height ? Does it represent heigh of the
+	// chain inside wasm smart contract ?
+	return h.Height
 }


### PR DESCRIPTION
As for now babylon callback is fixed on tendermint lc header. This will of course won't work if we would like to timestamp headers of wasm clients.

This pr:
- refactor our extended keeper `UpdateClient` function to use newly added functions form ibc-go/v7 client refactoring. This reduces duplication of the logic which needed to be added exclusively for Babylon
- generalize our `AfterHeaderWithValidCommit` callback to work with new interface which marks light client header (`LCHeader`). Application then will be able to further check what type of header this is to extract more fields.
