### PR TITLE
Simplify babylon custom logic for timestamping headers

### DIFF
--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -1,20 +1,17 @@
 package keeper
 
 import (
-	"bytes"
-	"reflect"
-	"time"
-
 	sdkerrors "cosmossdk.io/errors"
+	metrics "github.com/armon/go-metrics"
 	"github.com/cometbft/cometbft/crypto/tmhash"
-	"github.com/cometbft/cometbft/light"
-	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	ibcsltypes "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
 	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
@@ -25,6 +22,28 @@ import (
 type ExtendedKeeper struct {
 	Keeper
 	hooks ClientHooks
+}
+
+// GetHeaderInfo returns the information necessary for header timestamping or nil
+// if provided message is not a header
+func (ek ExtendedKeeper) GetHeaderInfo(ctx sdk.Context, m exported.ClientMessage) *HeaderInfo {
+	switch msg := m.(type) {
+	case *ibctmtypes.Header:
+		return &HeaderInfo{
+			Hash:     msg.Header.LastCommitHash,
+			ChaindId: msg.Header.ChainID,
+			Height:   uint64(msg.Header.Height),
+		}
+	case *ibcsltypes.Header:
+		return &HeaderInfo{
+			Hash:   msg.Signature,
+			Height: uint64(msg.Timestamp),
+			// there is no concpet of chain id in solo machine, just use client type for now
+			ChaindId: msg.ClientType(),
+		}
+	default:
+		return nil
+	}
 }
 
 // NewExtendedKeeper creates a new NewExtendedKeeper instance
@@ -57,242 +76,85 @@ func (ek *ExtendedKeeper) SetHooks(ch ClientHooks) *ExtendedKeeper {
 	return ek
 }
 
-// UpdateClient applies all verification rules on the header before executing the original UpdateClient() logic.
-// There are three possible outcomes after the verification:
-// 1. All verifications are passed: timestamp the header, pass the header to original UpdateClient()
-// 2. Verification fails with errors that only happen upon dishonest majority: timestamp the header, don't pass the header to original UpdateClient()
-// 3. Verification fails with normal errors: don't timestamp the header, don't pass the header to original UpdateClient()
-func (ek ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, header exported.ClientMessage) error {
-	// check if the client type is 07-tendermint
-	clientState, found := ek.GetClientState(ctx, clientID)
-	if !found {
-		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)
-	}
-	_, isTmClient := clientState.(*ibctmtypes.ClientState)
-
-	// Our logic only applies when
-	// - header is not nil (header can be nil in the original IBC-Go design, e.g., in `BeginBlocker`)
-	// - the client type is 07-tendermint (IBC-Go only supports 07-tendermint client at the moment)
-	if header == nil {
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
+// UpdateClient updates the consensus state and the state root from a provided header.
+// The implementation is the same as the original IBC-Go implementation, except from:
+// 1. Not freezing the client when finding a misbehaviour for header message
+// 2. Calling a AfterHeaderWithValidCommit callback when receiving valid header messages (either misbehaving or not)
+func (k ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, clientMsg exported.ClientMessage) error {
+	// In case of nil message nothing changes in comparison to the original IBC-Go implementation
+	if clientMsg == nil {
+		return k.Keeper.UpdateClient(ctx, clientID, clientMsg)
 	}
 
-	// TODO to support wasm client, we obviously need to do something different here.
-	// whole callback AfterHeaderWithValidCommit, must be generalized to support
-	// other client types, not only tendermint.
-	if !isTmClient {
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	}
-
-	switch msg := header.(type) {
-	case *ibctmtypes.Header:
-		// TODO in ibc-go v7 this whole verification was moved to seprarate function
-		// clientState.CheckForMisbehaviour. Probably we can do a lot of simplifications
-		// here.
-		err := ek.checkHeader(ctx, clientID, msg)
-
-		// good header, timestamp it on the canonical chain indexer
-		if err == nil {
-			txHash := tmhash.Sum(ctx.TxBytes())                    // get hash of the tx that includes this header
-			ek.AfterHeaderWithValidCommit(ctx, txHash, msg, false) // invoke hooks to notify ZoneConcierge to timestamp this header
-		}
-
-		// The header has a QC but {is on a fork, its timestamp is not monotonic}, timestamp it on the fork indexer, and return to avoid freezing the light client
-		// These two errors only happen upon dishonest majority
-		if sdkerrors.IsOf(err, types.ErrForkedHeaderWithValidCommit, types.ErrHeaderNonMonotonicTimestamp) {
-			ctx.Logger().Debug("received a header that has QC but is on a fork")
-			txHash := tmhash.Sum(ctx.TxBytes())
-			ek.AfterHeaderWithValidCommit(ctx, txHash, msg, true)
-			return err
-		}
-
-		// Upon other errors (that happen under honest majority), return error without timestamping it
-		if err != nil {
-			return err
-		}
-
-		// the header has a valid QC and is extending canonical chain
-		// follow the original verification rules to update client state
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	case *ibctmtypes.Misbehaviour:
-		// on Misbehaviour,just forward to standard client logic
-		return ek.Keeper.UpdateClient(ctx, clientID, header)
-	default:
-		return types.ErrInvalidClientType
-	}
-}
-
-// checkHeader checks
-// - if a header is on fork,
-// - if a header has a valid QC or not, and
-// - other miscellaneous verification rules
-// It is essentially `CheckHeaderAndUpdateState` without updating the state
-// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/core/02-client/keeper/client.go#L60)
-func (ek ExtendedKeeper) checkHeader(ctx sdk.Context, clientID string, tmHeader *ibctmtypes.Header) error {
-	clientState, found := ek.GetClientState(ctx, clientID)
+	clientState, found := k.GetClientState(ctx, clientID)
 	if !found {
 		return sdkerrors.Wrapf(types.ErrClientNotFound, "cannot update client with ID %s", clientID)
 	}
 
-	clientStore := ek.ClientStore(ctx, clientID)
-	if status := clientState.Status(ctx, clientStore, ek.cdc); status != exported.Active {
+	clientStore := k.ClientStore(ctx, clientID)
+
+	if status := clientState.Status(ctx, clientStore, k.cdc); status != exported.Active {
 		return sdkerrors.Wrapf(types.ErrClientNotActive, "cannot update client (%s) with status %s", clientID, status)
 	}
 
-	// Check if the header is on a fork
-	// If the consensus state exists, and it does not match this header, then this header is on a fork
-	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L63-L77)
-	isOnFork := false
-	prevConsState, _ := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	if prevConsState != nil {
-		if !reflect.DeepEqual(prevConsState, tmHeader.ConsensusState()) {
-			isOnFork = true
-		}
-	}
-
-	// Check if the header can pass all verification rules, including the QC
-	// Note that the first header on a fork can also be valid
-	// (adapted from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L79-L89)
-	trustedConsState, exists := ibctmtypes.GetConsensusState(clientStore, ek.cdc, tmHeader.TrustedHeight)
-	if !exists {
-		return sdkerrors.Wrapf(
-			types.ErrConsensusStateNotFound, "could not get consensus state from clientstore at TrustedHeight: %s", tmHeader.TrustedHeight,
-		)
-	}
-	// asserting clientState to that of Tendermint client
-	cs, ok := clientState.(*ibctmtypes.ClientState)
-	if !ok {
-		return sdkerrors.Wrapf(
-			types.ErrFailedClientStateVerification, "expected type %T, got %T", &ibctmtypes.ClientState{}, clientState,
-		)
-	}
-	if err := checkValidity(cs, trustedConsState, tmHeader, ctx.BlockTime()); err != nil {
+	if err := clientState.VerifyClientMessage(ctx, k.cdc, clientStore, clientMsg); err != nil {
 		return err
 	}
 
-	// this header passes QC verifications but is on a fork
-	if isOnFork {
-		return types.ErrForkedHeaderWithValidCommit
-	}
+	foundMisbehaviour := clientState.CheckForMisbehaviour(ctx, k.cdc, clientStore, clientMsg)
 
-	consState := tmHeader.ConsensusState()
-	// Check that consensus state timestamps are monotonic
-	prevCons, prevOk := ibctmtypes.GetPreviousConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	nextCons, nextOk := ibctmtypes.GetNextConsensusState(clientStore, ek.cdc, tmHeader.GetHeight())
-	// if previous consensus state exists, check consensus state time is greater than previous consensus state time
-	// if previous consensus state is not before current consensus state, freeze the client and return.
-	if prevOk && !prevCons.Timestamp.Before(consState.Timestamp) {
-		return types.ErrHeaderNonMonotonicTimestamp
-	}
-	// if next consensus state exists, check consensus state time is less than next consensus state time
-	// if next consensus state is not after current consensus state, freeze the client and return.
-	if nextOk && !nextCons.Timestamp.After(consState.Timestamp) {
-		return types.ErrHeaderNonMonotonicTimestamp
-	}
+	headerInfo := k.GetHeaderInfo(ctx, clientMsg)
 
-	return nil
-}
+	// found misbehaviour and it was not an header, freeze client
+	if foundMisbehaviour && headerInfo == nil {
+		clientState.UpdateStateOnMisbehaviour(ctx, k.cdc, clientStore, clientMsg)
 
-// checkValidity checks if the Tendermint header is valid.
-// CONTRACT: consState.Height == header.TrustedHeight
-// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L168-L248)
-func checkValidity(
-	clientState *ibctmtypes.ClientState, consState *ibctmtypes.ConsensusState,
-	header *ibctmtypes.Header, currentTimestamp time.Time,
-) error {
-	if err := checkTrustedHeader(header, consState); err != nil {
-		return err
-	}
+		k.Logger(ctx).Info("client frozen due to misbehaviour", "client-id", clientID)
 
-	// UpdateClient only accepts updates with a header at the same revision
-	// as the trusted consensus state
-	if header.GetHeight().GetRevisionNumber() != header.TrustedHeight.RevisionNumber {
-		return sdkerrors.Wrapf(
-			ibctmtypes.ErrInvalidHeaderHeight,
-			"header height revision %d does not match trusted header revision %d",
-			header.GetHeight().GetRevisionNumber(), header.TrustedHeight.RevisionNumber,
+		defer telemetry.IncrCounterWithLabels(
+			[]string{"ibc", "client", "misbehaviour"},
+			1,
+			[]metrics.Label{
+				telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+				telemetry.NewLabel(types.LabelClientID, clientID),
+				telemetry.NewLabel(types.LabelMsgType, "update"),
+			},
 		)
+
+		EmitSubmitMisbehaviourEvent(ctx, clientID, clientState)
+
+		return nil
+	} else if foundMisbehaviour && headerInfo != nil {
+		// found misbehaviour and it was an header, this is most probably means
+		// conflicting headers misbehaviour.
+		ctx.Logger().Debug("received a header that has QC but is on a fork")
+		txHash := tmhash.Sum(ctx.TxBytes())
+		k.AfterHeaderWithValidCommit(ctx, txHash, headerInfo, true)
+		return nil
 	}
 
-	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
-	if err != nil {
-		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
+	// there was no misbehaviour and we receivied an header, call the callback
+	if headerInfo != nil {
+		txHash := tmhash.Sum(ctx.TxBytes()) // get hash of the tx that includes this header
+		k.AfterHeaderWithValidCommit(ctx, txHash, headerInfo, false)
 	}
 
-	tmSignedHeader, err := tmtypes.SignedHeaderFromProto(header.SignedHeader)
-	if err != nil {
-		return sdkerrors.Wrap(err, "signed header in not tendermint signed header type")
-	}
+	consensusHeights := clientState.UpdateState(ctx, k.cdc, clientStore, clientMsg)
 
-	tmValidatorSet, err := tmtypes.ValidatorSetFromProto(header.ValidatorSet)
-	if err != nil {
-		return sdkerrors.Wrap(err, "validator set in not tendermint validator set type")
-	}
+	k.Logger(ctx).Info("client state updated", "client-id", clientID, "heights", consensusHeights)
 
-	// assert header height is newer than consensus state
-	if header.GetHeight().LTE(header.TrustedHeight) {
-		return sdkerrors.Wrapf(
-			types.ErrInvalidHeader,
-			"header height ≤ consensus state height (%s ≤ %s)", header.GetHeight(), header.TrustedHeight,
-		)
-	}
-
-	chainID := clientState.GetChainID()
-	// If chainID is in revision format, then set revision number of chainID with the revision number
-	// of the header we are verifying
-	// This is useful if the update is at a previous revision rather than an update to the latest revision
-	// of the client.
-	// The chainID must be set correctly for the previous revision before attempting verification.
-	// Updates for previous revisions are not supported if the chainID is not in revision format.
-	if types.IsRevisionFormat(chainID) {
-		chainID, _ = types.SetRevisionNumber(chainID, header.GetHeight().GetRevisionNumber())
-	}
-
-	// Construct a trusted header using the fields in consensus state
-	// Only Height, Time, and NextValidatorsHash are necessary for verification
-	trustedHeader := tmtypes.Header{
-		ChainID:            chainID,
-		Height:             int64(header.TrustedHeight.RevisionHeight),
-		Time:               consState.Timestamp,
-		NextValidatorsHash: consState.NextValidatorsHash,
-	}
-	signedHeader := tmtypes.SignedHeader{
-		Header: &trustedHeader,
-	}
-
-	// Verify next header with the passed-in trustedVals
-	// - asserts trusting period not passed
-	// - assert header timestamp is not past the trusting period
-	// - assert header timestamp is past latest stored consensus state timestamp
-	// - assert that a TrustLevel proportion of TrustedValidators signed new Commit
-	err = light.Verify(
-		&signedHeader,
-		tmTrustedValidators, tmSignedHeader, tmValidatorSet,
-		clientState.TrustingPeriod, currentTimestamp, clientState.MaxClockDrift, clientState.TrustLevel.ToTendermint(),
+	defer telemetry.IncrCounterWithLabels(
+		[]string{"ibc", "client", "update"},
+		1,
+		[]metrics.Label{
+			telemetry.NewLabel(types.LabelClientType, clientState.ClientType()),
+			telemetry.NewLabel(types.LabelClientID, clientID),
+			telemetry.NewLabel(types.LabelUpdateType, "msg"),
+		},
 	)
-	if err != nil {
-		return sdkerrors.Wrap(err, "failed to verify header")
-	}
-	return nil
-}
 
-// checkTrustedHeader checks that consensus state matches trusted fields of Header
-// (copied from https://github.com/cosmos/ibc-go/blob/v5.0.0/modules/light-clients/07-tendermint/types/update.go#L148-L166)
-func checkTrustedHeader(header *ibctmtypes.Header, consState *ibctmtypes.ConsensusState) error {
-	tmTrustedValidators, err := tmtypes.ValidatorSetFromProto(header.TrustedValidators)
-	if err != nil {
-		return sdkerrors.Wrap(err, "trusted validator set in not tendermint validator set type")
-	}
+	// emitting events in the keeper emits for both begin block and handler client updates
+	EmitUpdateClientEvent(ctx, clientID, clientState.ClientType(), consensusHeights, k.cdc, clientMsg)
 
-	// assert that trustedVals is NextValidators of last trusted header
-	// to do this, we check that trustedVals.Hash() == consState.NextValidatorsHash
-	tvalHash := tmTrustedValidators.Hash()
-	if !bytes.Equal(consState.NextValidatorsHash, tvalHash) {
-		return sdkerrors.Wrapf(
-			ibctmtypes.ErrInvalidValidatorSet,
-			"trusted validators %s, does not hash to latest trusted validators. Expected: %X, got: %X",
-			header.TrustedValidators, consState.NextValidatorsHash, tvalHash,
-		)
-	}
 	return nil
 }

--- a/modules/core/02-client/keeper/extended_keeper.go
+++ b/modules/core/02-client/keeper/extended_keeper.go
@@ -11,7 +11,6 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
-	ibcsltypes "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
 	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
@@ -26,20 +25,13 @@ type ExtendedKeeper struct {
 
 // GetHeaderInfo returns the information necessary for header timestamping or nil
 // if provided message is not a header
-func (ek ExtendedKeeper) GetHeaderInfo(ctx sdk.Context, m exported.ClientMessage) *HeaderInfo {
+func GetHeaderInfo(ctx sdk.Context, m exported.ClientMessage) *HeaderInfo {
 	switch msg := m.(type) {
 	case *ibctmtypes.Header:
 		return &HeaderInfo{
 			Hash:     msg.Header.LastCommitHash,
 			ChaindId: msg.Header.ChainID,
 			Height:   uint64(msg.Header.Height),
-		}
-	case *ibcsltypes.Header:
-		return &HeaderInfo{
-			Hash:   msg.Signature,
-			Height: uint64(msg.Timestamp),
-			// there is no concpet of chain id in solo machine, just use client type for now
-			ChaindId: msg.ClientType(),
 		}
 	default:
 		return nil
@@ -103,7 +95,7 @@ func (k ExtendedKeeper) UpdateClient(ctx sdk.Context, clientID string, clientMsg
 
 	foundMisbehaviour := clientState.CheckForMisbehaviour(ctx, k.cdc, clientStore, clientMsg)
 
-	headerInfo := k.GetHeaderInfo(ctx, clientMsg)
+	headerInfo := GetHeaderInfo(ctx, clientMsg)
 
 	// found misbehaviour and it was not an header, freeze client
 	if foundMisbehaviour && headerInfo == nil {

--- a/modules/core/02-client/keeper/extended_keeper_hooks.go
+++ b/modules/core/02-client/keeper/extended_keeper_hooks.go
@@ -2,12 +2,17 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
 // ClientHooks defines the hook interface for client
 type ClientHooks interface {
-	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool)
+	AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *HeaderInfo, isOnFork bool)
+}
+
+type HeaderInfo struct {
+	Hash     []byte
+	ChaindId string
+	Height   uint64
 }
 
 // MultiClientHooks is a concrete implementation of ClientHooks
@@ -21,7 +26,7 @@ func NewMultiClientHooks(hooks ...ClientHooks) MultiClientHooks {
 }
 
 // invoke hooks in each keeper that hooks onto ExtendedKeeper
-func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
+func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *HeaderInfo, isOnFork bool) {
 	for i := range h {
 		h[i].AfterHeaderWithValidCommit(ctx, txHash, header, isOnFork)
 	}
@@ -30,7 +35,7 @@ func (h MultiClientHooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []b
 // ensure ExtendedKeeper implements ClientHooks interfaces
 var _ ClientHooks = ExtendedKeeper{}
 
-func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
+func (ek ExtendedKeeper) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *HeaderInfo, isOnFork bool) {
 	if ek.hooks != nil {
 		ek.hooks.AfterHeaderWithValidCommit(ctx, txHash, header, isOnFork)
 	}


### PR DESCRIPTION
Successor to https://github.com/babylonchain/ibc-go/pull/5. 

Approach is a bit changed in comparison to old pr to avoid adding additional interface at library level. This way if ibc-go will use ClientKeeper interface instead of concrete keeper, we will be able whole thing on babylon side without forking ibc-go.

Tested this with Babylon and all Zoneconcierge tests are passing.